### PR TITLE
Use cdupdate.sh, remove squashfs modification and sudo needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,8 @@ It lets you take control of the PXE host easily:
 
 * The `cpio` command from `app-arch/cpio`
 * The `gpg` command from `app-crypt/gnupg`
-* The `unsquashfs` and `mksquashfs` command from `sys-fs/squashfs-tools`
-* The `sudo` command from `app-admin/sudo`
+* The `xz` command from `app-arch/xz-utils`
 * The `isoinfo` command from `app-cdr/cdrtools`
-* Your current user must be a sudoer with the right to execute any command
 * You must have imported the 'Gentoo Linux Release Engineering (Automated Weekly Release Key)' GPG public key in your keyring `gpg --locate-key releng@gentoo.org`
 
 ## Environment variables and defaults
@@ -47,8 +45,8 @@ The default SSH root password is `gentoo-root`. This is the list of accepted env
 * Install `sys-boot/syslinux` as it contains the necessary files:
 
 ```
-$ sudo cp /usr/share/syslinux/ldlinux.c32 /pxe/
-$ sudo cp /usr/share/syslinux/pxelinux.0 /pxe/
+# cp /usr/share/syslinux/ldlinux.c32 /pxe/
+# cp /usr/share/syslinux/pxelinux.0 /pxe/
 ```
 
 * Create the `/pxe/pxelinux.cfg/` directory

--- a/files/cdupdate.sh
+++ b/files/cdupdate.sh
@@ -1,0 +1,19 @@
+
+# we should be in newroot ${NEW_ROOT} and other nice things are unavailable
+echo "  Running cdupdate.sh in $(pwd)"
+echo "  Started as: $0 args: $*"
+
+scriptpath=$(dirname $0)
+echo " found scriptpath: ${scriptpath}"
+
+set -x
+cp ${scriptpath}/setup.start etc/local.d/
+chmod +x etc/local.d/setup.start
+
+if [ -f "${scriptpath}/authorized_keys" ]; then
+	mkdir -p root/.ssh
+	cp "${scriptpath}/authorized_keys" root/.ssh/authorized_keys
+	chmod 600 root/.ssh/authorized_keys
+fi
+
+set +x


### PR DESCRIPTION
Move modification logic from build.sh into cdupdate.sh
Include files via cpio instead, cdupdate.sh will see to correct modification.

This removes need for squashfs rebuild, which in turn removes need for sudo.
This should be much quicker and cleaner